### PR TITLE
shareViaFacebookWithPasteMessageHint: Strip link from prefilled message

### DIFF
--- a/src/ios/SocialSharing.m
+++ b/src/ios/SocialSharing.m
@@ -208,7 +208,7 @@ static NSString *const kShareOptionUrl = @"url";
       NSString *messageWithoutLink = [linkEx stringByReplacingMatchesInString:message options:0 range:NSMakeRange(0, [message length]) withTemplate:@""];
       NSMutableArray *mutableArguments = [command.arguments mutableCopy];
       [mutableArguments replaceObjectAtIndex:0 withObject:messageWithoutLink];
-      command.arguments = [NSArray arrayWithArray:mutableArguments];
+      command = [[CDVInvokedUrlCommand alloc] initWithArguments:[NSArray arrayWithArray:mutableArguments] callbackId:command.callbackId className:command.className methodName:command.methodName];
     }
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1000 * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{


### PR DESCRIPTION
In case of image sharing + prefilled text containing a link: strip links from message, else Facebook would consider it as link sharing and will ignore image sharing